### PR TITLE
Unescape dash after bold element

### DIFF
--- a/src/main/java/com/overzealous/remark/convert/TextCleaner.java
+++ b/src/main/java/com/overzealous/remark/convert/TextCleaner.java
@@ -167,7 +167,7 @@ public class TextCleaner {
 		escapes.add(new Escape(chars.toString(), "\\\\$1"));
 
 		// finally, escape certain characters only if they are leading characters
-		StringBuilder leadingChars = new StringBuilder("^( ?+)([\\Q-+");
+		StringBuilder leadingChars = new StringBuilder("^( ?+)([\\Q+");
 		if(options.definitionLists) {
 			leadingChars.append(':');
 		}

--- a/src/test/java/com/overzealous/remark/convert/MarkdownExtraTest.java
+++ b/src/test/java/com/overzealous/remark/convert/MarkdownExtraTest.java
@@ -46,5 +46,6 @@ public class MarkdownExtraTest extends RemarkTester {
 	@Test public void testParagraph()		throws Exception { test("paragraph"); }
 	@Test public void testTables()			throws Exception { test("tables", "markdownextra"); }
 	@Test public void testUnknownHTML()		throws Exception { test("unknownHTML"); }
+	@Test public void testBoldWithDash()	throws Exception { test("bold-with-dash"); }
 	
 }

--- a/src/test/resources/conversions/html/bold-with-dash.html
+++ b/src/test/resources/conversions/html/bold-with-dash.html
@@ -1,0 +1,1 @@
+<b>bold</b> - normal

--- a/src/test/resources/conversions/markdown/bold-with-dash.md
+++ b/src/test/resources/conversions/markdown/bold-with-dash.md
@@ -1,0 +1,1 @@
+**bold** - normal


### PR DESCRIPTION
Hi, thanks for this library.
I had problems with a dash character after a bold element:

```
input:
<b>bold</b> - normal
output:
**bold** \- normal
```

I wanted to have the dash unescaped. Hence the PR.

```
input:
<b>bold</b> - normal
output:
**bold** - normal
```

Please let me know if it was an expected behavior.

P.S.
BTW, `build.gradle` is a bit out of date. It's not compatible with gradle >=v3