### PR TITLE
Upgrade the outdated dependencies to resolve vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
     <developers>
         <developer>
             <name>Phil DeJarnett</name>
@@ -68,26 +72,26 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.6.3</version>
+            <version>1.14.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.12.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <!-- needed to use command line utility -->
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.5.0</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
The main component to update is jsoup 1.9.2 which has the vulnerability CVE-2021-37714
Updating to 1.14.3.